### PR TITLE
fix: missing external dependencies to injectify core lib

### DIFF
--- a/src/Injectify.Autofac/Injectify.Autofac.nuspec
+++ b/src/Injectify.Autofac/Injectify.Autofac.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Injectify.Autofac</id>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
     <title>Injectify.Autofac</title>
     <authors>Vlad Khrapov</authors>
     <owners>Vlad Khrapov</owners>
@@ -14,8 +14,9 @@
     <copyright>Copyright © 2022</copyright>
     <tags>UWP; DI; DependencyInjection; Injectify; Autofac;</tags>
     <dependencies>
-      <!-- <group targetFramework=".NETFramework4.7.2" /> -->
       <dependency id="Autofac" version="5.0.0" />
+      <dependency id="Injectify" version="0.6.0" />
+      <dependency id="Injectify.Abstractions" version="0.6.0" />
       <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10" />
     </dependencies>
   </metadata>

--- a/src/Injectify.Microsoft.DependencyInjection/Injectify.Microsoft.DependencyInjection.nuspec
+++ b/src/Injectify.Microsoft.DependencyInjection/Injectify.Microsoft.DependencyInjection.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Injectify.Microsoft.DependencyInjection</id>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
     <title>Injectify.Microsoft.DependencyInjection</title>
     <authors>Vlad Khrapov</authors>
     <owners>Vlad Khrapov</owners>
@@ -14,7 +14,8 @@
     <copyright>Copyright © 2022</copyright>
     <tags>UWP; DI; DependencyInjection; Injectify; Microsoft.Extensions.DependencyInjection;</tags>
     <dependencies>
-      <!-- <group targetFramework=".NETFramework4.7.2" /> -->
+      <dependency id="Injectify" version="0.6.0" />
+      <dependency id="Injectify.Abstractions" version="0.6.0" />
       <dependency id="Microsoft.Extensions.DependencyInjection" version="3.1.7" />
       <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="3.1.7" />
       <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10" />


### PR DESCRIPTION
Fix issue with missing dependencies in order to reference only a single DI specific connector